### PR TITLE
fix: add description in input schema for createShop mutation

### DIFF
--- a/src/mutations/createShop.js
+++ b/src/mutations/createShop.js
@@ -104,7 +104,7 @@ export default async function createShop(context, input) {
       {
         uol: "ft",
         label: "Feet"
-      },
+      }
     ],
     unitsOfMeasure: [
       {
@@ -123,7 +123,7 @@ export default async function createShop(context, input) {
       {
         uom: "kg",
         label: "Kilograms"
-      },
+      }
     ],
     updatedAt: now
   };


### PR DESCRIPTION
The `description` field is missing in the input schema when you are creating a shop. It's defined in the graphql schema but not in the validation schema. So, if you create a shop with description, the API throws a validation error.

This PR adds `description` in the input schema for `createShop`.

Partially resolves https://github.com/reactioncommerce/reaction/issues/6147 (still missing the integration tests for the reaction api)

## Testing
1. Checkout locally this branch, npm install, and link it to your reaction api (update `docker-compose.dev.yml` and remove plugin from `package.json`)
2. Create a shop and populate the `description` field

Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>