### PR TITLE
Add shops query

### DIFF
--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,6 +1,9 @@
+import shops from "./shops.js";
+
 export default {
   shopById: (context, _id) => context.dataLoaders.Shops.load(_id),
   shopBySlug: (context, slug) => context.collections.Shops.findOne({ slug }),
+  shops,
   primaryShop: (context) => context.collections.Shops.findOne({ shopType: "primary" }),
   async primaryShopId(context) {
     const shop = await context.collections.Shops.findOne({

--- a/src/queries/shops.js
+++ b/src/queries/shops.js
@@ -1,0 +1,29 @@
+/**
+ * @name shops
+ * @summary Query the Shops collection for a list of shops.
+ *   If shopIds are provided, return the matching shops. Otherwise, return all the shops.
+ * @param {Object} context - an object containing the per-request state
+ * @param {Array} shopIds - optional array of shop IDs to return
+ * @returns {Promise<Object>} Products object Promise
+ */
+export default async function shops(context, shopIds) {
+  const { collections } = context;
+  const { Shops } = collections;
+
+  if (Array.isArray(shopIds) && shopIds.length > 0) {
+    // make sure we're authorized to read all the requested shopIds
+    for (const shopId of shopIds) {
+      await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
+    }
+
+    return Shops.find({
+      _id: {
+        $in: shopIds
+      }
+    });
+  }
+
+  await context.validatePermissions("reaction:legacy:shops", "read", { shopId: null });
+
+  return Shops.find();
+}

--- a/src/queries/shops.js
+++ b/src/queries/shops.js
@@ -10,20 +10,20 @@ export default async function shops(context, shopIds) {
   const { collections } = context;
   const { Shops } = collections;
 
-  // if (Array.isArray(shopIds) && shopIds.length > 0) {
-  //   // make sure we're authorized to read all the requested shopIds
-  //   for (const shopId of shopIds) {
-  //     await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
-  //   }
-  //
-  //   return Shops.find({
-  //     _id: {
-  //       $in: shopIds
-  //     }
-  //   });
-  // }
+  if (Array.isArray(shopIds) && shopIds.length > 0) {
+    // make sure we're authorized to read all the requested shopIds
+    for (const shopId of shopIds) {
+      await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
+    }
 
-  // await context.validatePermissions("reaction:legacy:shops:*", "read");
+    return Shops.find({
+      _id: {
+        $in: shopIds
+      }
+    });
+  }
+
+  await context.validatePermissions("reaction:legacy:shops", "read", { shopId: null });
 
   return Shops.find();
 }

--- a/src/queries/shops.js
+++ b/src/queries/shops.js
@@ -11,7 +11,7 @@ export default async function shops(context, { shopIds } = {}) {
 const { collections } = context;
   const { Shops } = collections;
 
-  if (Array.isArray(shopIds) && shopIds.length > 0) {
+  if (Array.isArray(shopIds)) {
     // make sure we're authorized to read all the requested shopIds
     for (const shopId of shopIds) {
       await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });

--- a/src/queries/shops.js
+++ b/src/queries/shops.js
@@ -3,11 +3,12 @@
  * @summary Query the Shops collection for a list of shops.
  *   If shopIds are provided, return the matching shops. Otherwise, return all the shops.
  * @param {Object} context - an object containing the per-request state
- * @param {Array} shopIds - optional array of shop IDs to return
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} [args.shopIds] - optional array of shop IDs to return
  * @returns {Promise<Object>} Products object Promise
  */
-export default async function shops(context, shopIds) {
-  const { collections } = context;
+export default async function shops(context, { shopIds } = {}) {
+const { collections } = context;
   const { Shops } = collections;
 
   if (Array.isArray(shopIds) && shopIds.length > 0) {

--- a/src/queries/shops.js
+++ b/src/queries/shops.js
@@ -10,20 +10,20 @@ export default async function shops(context, shopIds) {
   const { collections } = context;
   const { Shops } = collections;
 
-  if (Array.isArray(shopIds) && shopIds.length > 0) {
-    // make sure we're authorized to read all the requested shopIds
-    for (const shopId of shopIds) {
-      await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
-    }
+  // if (Array.isArray(shopIds) && shopIds.length > 0) {
+  //   // make sure we're authorized to read all the requested shopIds
+  //   for (const shopId of shopIds) {
+  //     await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
+  //   }
+  //
+  //   return Shops.find({
+  //     _id: {
+  //       $in: shopIds
+  //     }
+  //   });
+  // }
 
-    return Shops.find({
-      _id: {
-        $in: shopIds
-      }
-    });
-  }
-
-  await context.validatePermissions("reaction:legacy:shops", "read", { shopId: null });
+  // await context.validatePermissions("reaction:legacy:shops:*", "read");
 
   return Shops.find();
 }

--- a/src/resolvers/Query/index.js
+++ b/src/resolvers/Query/index.js
@@ -2,10 +2,12 @@ import primaryShopId from "./primaryShopId.js";
 import primaryShop from "./primaryShop.js";
 import shop from "./shop.js";
 import shopBySlug from "./shopBySlug.js";
+import shops from "./shops.js";
 
 export default {
   primaryShopId,
   primaryShop,
   shop,
-  shopBySlug
+  shopBySlug,
+  shops
 };

--- a/src/resolvers/Query/shops.js
+++ b/src/resolvers/Query/shops.js
@@ -19,7 +19,11 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @returns {Promise<Object[]>} Promise that resolves with array of shop objects
  */
 export default async function shops(_, { shopIds, ...connectionArgs }, context, info) {
-  const decodedShopIds = shopIds.map((shopId) => decodeShopOpaqueId(shopId));
+  let decodedShopIds;
+
+  if (Array.isArray(shopIds) && shopIds.length > 0) {
+    decodedShopIds = shopIds.map((shopId) => decodeShopOpaqueId(shopId));
+  }
 
   const query = await context.queries.shops(context, decodedShopIds);
 

--- a/src/resolvers/Query/shops.js
+++ b/src/resolvers/Query/shops.js
@@ -1,6 +1,6 @@
 import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
 import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
-import { decodeShopOpaqueId } from "../../xforms/id";
+import { decodeShopOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Shop/shops

--- a/src/resolvers/Query/shops.js
+++ b/src/resolvers/Query/shops.js
@@ -1,0 +1,31 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeShopOpaqueId } from "../../xforms/id";
+
+/**
+ * @name Shop/shops
+ * @method
+ * @memberof Shop/GraphQL
+ * @summary find and return the shops for a shop
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} args.shopIds - Optional shopIds to filter by
+ * @param {String} args.after - Connection argument
+ * @param {String} args.before - Connection argument
+ * @param {Number} args.first - Connection argument
+ * @param {Number} args.last - Connection argument
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object[]>} Promise that resolves with array of shop objects
+ */
+export default async function shops(_, { shopIds, ...connectionArgs }, context, info) {
+  const decodedShopIds = shopIds.map((shopId) => decodeShopOpaqueId(shopId));
+
+  const query = await context.queries.shops(context, decodedShopIds);
+
+  return getPaginatedResponse(query, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/resolvers/Query/shops.js
+++ b/src/resolvers/Query/shops.js
@@ -25,7 +25,7 @@ export default async function shops(_, { shopIds, ...connectionArgs }, context, 
     decodedShopIds = shopIds.map((shopId) => decodeShopOpaqueId(shopId));
   }
 
-  const query = await context.queries.shops(context, decodedShopIds);
+  const query = await context.queries.shops(context, { shopIds: decodedShopIds });
 
   return getPaginatedResponse(query, connectionArgs, {
     includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -148,4 +148,15 @@ extend type Query {
     "The shop slug"
     slug: String!
   ): Shop
+
+  shops(
+    "Return at most this many results. This parameter may be used with the `offset` parameter."
+    first: ConnectionLimitInt
+
+    "Return at most this many results."
+    last: ConnectionLimitInt
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int
+  ): [Shop]
 }

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -15,8 +15,8 @@ type ShopLogoUrls {
 
 "Storefront route URLs"
 type StorefrontUrls {
-  "Storefront Account Profile URL (can include `:accountId` in string)"
-  storefrontAccountProfileUrl: String
+  "Storefront Shop Profile URL (can include `:ShopId` in string)"
+  storefrontShopProfileUrl: String
 
   "Storefront Home URL"
   storefrontHomeUrl: String
@@ -27,7 +27,7 @@ type StorefrontUrls {
   "Storefront single order URL (can include `:orderReferenceId` and `:orderToken` in string)"
   storefrontOrderUrl: String
 
-  "Storefront orders URL (can include `:accountId` in string)"
+  "Storefront orders URL (can include `:ShopId` in string)"
   storefrontOrdersUrl: String
 }
 
@@ -78,7 +78,7 @@ type Shop implements Node {
   "An the shop's default address"
   addressBook: [Address]
 
-  "Whether to allow user to checkout without creating an account"
+  "Whether to allow user to checkout without creating an Shop"
   allowGuestCheckout: Boolean
 
   "The base unit of length"
@@ -130,6 +130,40 @@ type Shop implements Node {
   unitsOfMeasure: [UnitOfMeasure]
 }
 
+"""
+Wraps a list of `Shops`, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type ShopConnection {
+  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+  edges: [ShopEdge]
+
+  """
+  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+  if you know you will not need to paginate the results.
+  """
+  nodes: [Shop]
+
+  "Information to help a client request the next or previous page"
+  pageInfo: PageInfo!
+
+  "The total number of nodes that match your query"
+  totalCount: Int!
+}
+
+"A connection edge in which each node is an `Shop` object"
+type ShopEdge implements NodeEdge {
+  "The cursor that represents this node in the paginated results"
+  cursor: ConnectionCursor!
+
+  "The Shop"
+  node: Shop
+}
+
 extend type Query {
   "Returns the primary shop for the domain"
   primaryShop: Shop
@@ -173,5 +207,5 @@ extend type Query {
 
     "By default, groups are sorted by when they were created, oldest first. Set this to sort by one of the other allowed fields"
     sortBy: GroupSortByField = createdAt
-  ): [Shop]
+  ): ShopConnection
 }

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -150,13 +150,28 @@ extend type Query {
   ): Shop
 
   shops(
-    "Return at most this many results. This parameter may be used with the `offset` parameter."
-    first: ConnectionLimitInt
+    "Shop IDs to filter by"
+    shopIds: [ID],
 
-    "Return at most this many results."
-    last: ConnectionLimitInt
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
 
     "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
-    offset: Int
+    offset: Int,
+
+    "Return results sorted in this order"
+    sortOrder: SortOrder = asc,
+
+    "By default, groups are sorted by when they were created, oldest first. Set this to sort by one of the other allowed fields"
+    sortBy: GroupSortByField = createdAt
   ): [Shop]
 }

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -15,8 +15,8 @@ type ShopLogoUrls {
 
 "Storefront route URLs"
 type StorefrontUrls {
-  "Storefront Shop Profile URL (can include `:ShopId` in string)"
-  storefrontShopProfileUrl: String
+  "Storefront Account Profile URL (can include `:accountId` in string)"
+  storefrontAccountProfileUrl: String
 
   "Storefront Home URL"
   storefrontHomeUrl: String
@@ -27,7 +27,7 @@ type StorefrontUrls {
   "Storefront single order URL (can include `:orderReferenceId` and `:orderToken` in string)"
   storefrontOrderUrl: String
 
-  "Storefront orders URL (can include `:ShopId` in string)"
+  "Storefront orders URL (can include `:accountId` in string)"
   storefrontOrdersUrl: String
 }
 
@@ -78,7 +78,7 @@ type Shop implements Node {
   "An the shop's default address"
   addressBook: [Address]
 
-  "Whether to allow user to checkout without creating an Shop"
+  "Whether to allow user to checkout without creating an account"
   allowGuestCheckout: Boolean
 
   "The base unit of length"


### PR DESCRIPTION
Impact: **major**
Type: **feature**

## Issue
There is currently no `shops` query, and hence no way to list all the shops that a Reaction Commerce instance has.

## Solution
Create a paginated `shops` query that takes an optional `shopIds` array for filtering results.

## Breaking changes
None.

## Testing
1. Call `shops` without `shopIds`.
2. See that all of the instance's shops are returned.
3. Call `shops` with some `shopIds`.
4. See that the shops you passed IDs for are returned.