### PR TITLE
feat: add shopType to Shop schema

### DIFF
--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -114,6 +114,9 @@ type Shop implements Node {
   "Returns URLs for shop logos"
   shopLogoUrls: ShopLogoUrls
 
+  "Shop's type"
+  shopType: String
+
   "Shop's slug"
   slug: String
 


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #14
Impact: **minor**
Type: **feature**

## Issue
There's no way to get `shopType` when querying a shop.

## Solution
Include `shopType` in the `Shop` schema.

## Breaking changes
None.

## Testing
1. Query `shop($id: ID!)`.
2. Request `shopType` in the response.
3. Get `shopType` as requested.