### PR TITLE
fix: default to type merchant if primary exists

### DIFF
--- a/src/mutations/createShop.test.js
+++ b/src/mutations/createShop.test.js
@@ -7,6 +7,7 @@ mockContext.simpleSchemas = simpleSchemas;
 
 test("creates shop with type primary if there is no existing shop", async () => {
   mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(null));
+  mockContext.collections.Shops.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));
 
   await expect(createShop(mockContext, {
     name: "First shop"
@@ -21,6 +22,7 @@ test("creates shop with type merchant if there is already a primary", async () =
     shopType: "primary",
     name: "First shop"
   });
+  mockContext.collections.Shops.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));
 
   await expect(createShop(mockContext, {
     name: "Second shop"

--- a/src/mutations/createShop.test.js
+++ b/src/mutations/createShop.test.js
@@ -1,0 +1,28 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import createShop from "./createShop.js";
+
+mockContext.mutations.createProduct = jest.fn().mockName("mutations.createProduct");
+
+test("creates shop with type primary if there is no existing shop", async () => {
+  mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(null));
+
+  await expect(createShop(mockContext, {
+    name: "First shop"
+  })).resolves.toEqual(expect.objectContaining({
+    shopType: "primary"
+  }));
+});
+
+test("creates shop with type merchant if there is already a primary", async () => {
+  mockContext.collections.Shops.findOne.mockReturnValueOnce({
+    _id: "1234",
+    shopType: "primary",
+    name: "First shop"
+  });
+
+  await expect(createShop(mockContext, {
+    name: "Second shop"
+  })).resolves.toEqual(expect.objectContaining({
+    shopType: "merchant"
+  }));
+});

--- a/src/mutations/createShop.test.js
+++ b/src/mutations/createShop.test.js
@@ -1,6 +1,6 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
-import createShop from "./createShop.js";
 import * as simpleSchemas from "../simpleSchemas.js";
+import createShop from "./createShop.js";
 
 mockContext.mutations.createProduct = jest.fn().mockName("mutations.createProduct");
 mockContext.simpleSchemas = simpleSchemas;

--- a/src/mutations/createShop.test.js
+++ b/src/mutations/createShop.test.js
@@ -1,7 +1,9 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import createShop from "./createShop.js";
+import * as simpleSchemas from "../simpleSchemas.js";
 
 mockContext.mutations.createProduct = jest.fn().mockName("mutations.createProduct");
+mockContext.simpleSchemas = simpleSchemas;
 
 test("creates shop with type primary if there is no existing shop", async () => {
   mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(null));


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #20 
Impact: **critical**
Type: **bugfix**

## Issue
On an instance of Reaction with a primary shop already created, creating subsequent shops without explicitly passing a `shopType` fails. This is because the `createShop` mutation defaults `shopType` to `primary`, even though a `primary` shop might already exist.

## Solution
In the `createShop` mutation logic, when a `shopType` is not provided, only default to `primary` if a primary shop doesn't already exist. In case a primary shop already exists and no `shopType` is provided, default the value to `merchant`.

## Breaking changes
None.

## Testing
1. On a blank instance of Open Commerce, create a first shop, either through the `createShop` mutation (with no explicit `shopType`), or through `reaction-admin`.
2. Check the `shopType` property for that shop in the database. The value should be `primary`, because this is the first shop to be created.
3. Create a second shop, either through the `createShop` mutation (with no explicit `shopType`), or through `reaction-admin`.
4. The creation of the shop should not fail, and the `shopType` should be `merchant` by default.