### PR TITLE
feat: allow extending shop before creation

### DIFF
--- a/src/mutations/createShop.js
+++ b/src/mutations/createShop.js
@@ -142,6 +142,10 @@ export default async function createShop(context, input) {
     shop.shopType = type;
   }
 
+  for (const func of context.getFunctionsOfType("mutateShopBeforeCreate")) {
+    await func(context, shop); // eslint-disable-line no-await-in-loop
+  }
+
   ShopSchema.validate(shop);
 
   // Ensure we never have more than one primary shop

--- a/src/mutations/createShop.test.js
+++ b/src/mutations/createShop.test.js
@@ -5,14 +5,35 @@ import createShop from "./createShop.js";
 mockContext.mutations.createProduct = jest.fn().mockName("mutations.createProduct");
 mockContext.simpleSchemas = simpleSchemas;
 
+/**
+ * @summary Creates a mock plugin that extends the shop schema mutates the shop before being created
+ * @param {Object} context - mock context
+ * @return {undefined}
+ */
+function mockPluginExtendingShop(context) {
+  context.simpleSchemas.Shop.extend({
+    externalShopProp: {
+      type: String,
+      optional: true
+    }
+  });
+  context.getFunctionsOfType.mockReturnValueOnce([
+    (_, shop) => {
+      shop.externalShopProp = "externalValue";
+    }
+  ]);
+}
+
 test("creates shop with type primary if there is no existing shop", async () => {
   mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(null));
   mockContext.collections.Shops.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));
+  mockPluginExtendingShop(mockContext);
 
   await expect(createShop(mockContext, {
     name: "First shop"
   })).resolves.toEqual(expect.objectContaining({
-    shopType: "primary"
+    shopType: "primary",
+    externalShopProp: "externalValue"
   }));
 });
 


### PR DESCRIPTION
Signed-off-by: tedraykov <tedraykov@gmail.com>

Impact: **minor**
Type: **feature**

## Issue
When creating a shop, there is no way to extend the schema from another plugin and add extra properties to the shop.

## Solution
Running all `FunctionsOfType` "mutateShopBeforeCreate" before the shop is created. This allows extending the shop.

## Breaking changes
None

## Testing
1. Updated unit tests to validate the shop is extended